### PR TITLE
Simplify PackageRegistry.sol

### DIFF
--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -1,0 +1,63 @@
+pragma solidity ^0.5.0;
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract Ownable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor () internal {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), _owner);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(isOwner(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Returns true if the caller is the current owner.
+     */
+    function isOwner() public view returns (bool) {
+        return msg.sender == _owner;
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public onlyOwner {
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     */
+    function _transferOwnership(address newOwner) internal {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}

--- a/contracts/PackageRegistry.sol
+++ b/contracts/PackageRegistry.sol
@@ -1,0 +1,373 @@
+pragma solidity >=0.5.10;
+
+import {PackageRegistryInterface} from "./PackageRegistryInterface.sol";
+import {Ownable} from "./Ownable.sol";
+
+/// @title Contract for an ERC1319 Registry, adapted from ethpm/escape-truffle
+/// @author Nick Gheorghita <nickg@ethereum.org>
+contract PackageRegistry is PackageRegistryInterface, Ownable {
+    struct Package {
+        bool exists;
+        uint createdAt;
+        uint updatedAt;
+        uint releaseCount;
+        string name;
+    }
+
+    struct Release {
+        bool exists;
+        uint createdAt;
+        bytes32 packageId;
+        string version;
+        string manifestURI;
+    }
+
+    mapping (bytes32 => Package) public packages;
+    mapping (bytes32 => Release) public releases;
+
+    // package_id#release_count => release_id
+    mapping (bytes32 => bytes32) packageReleaseIndex;
+    // Total package number (int128) => package_id (bytes32)
+    mapping (uint => bytes32) allPackageIds;
+    // Total release number (int128) => release_id (bytes32)
+    mapping (uint => bytes32) allReleaseIds;
+    // Total number of packages in registry
+    uint public packageCount;
+    // Total number of releases in registry
+    uint public releaseCount;
+
+    // Events
+    event VersionRelease(string packageName, string version, string manifestURI);
+    event PackageTransfer(address indexed oldOwner, address indexed newOwner);
+
+    // Modifiers
+    modifier onlyIfPackageExists(string memory packageName) {
+        require(packageExists(packageName), "package-does-not-exist");
+        _;
+    }
+
+    modifier onlyIfReleaseExists(string memory packageName, string memory version) {
+        require (releaseExists(packageName, version), "release-does-not-exist");
+        _;
+    }
+
+    //
+    // ===============
+    // |  Write API  |
+    // ===============
+    //
+
+    /// @dev Creates a new release for the named package.  If this is the first release for the given
+    /// package then this will also create and store the package.  Returns releaseID if successful.
+    /// @notice Will create a new release the given package with the given release information.
+    /// @param packageName Package name
+    /// @param version Version string (ex: '1.0.0')
+    /// @param manifestURI The URI for the release manifest for this release.
+    function release(
+        string memory packageName,
+        string memory version,
+        string memory manifestURI
+    )
+        public
+        onlyOwner
+        returns (bytes32)
+    {
+        validatePackageName(packageName);
+        validateStringIdentifier(version);
+        validateStringIdentifier(manifestURI);
+
+        // Compute hashes
+        bytes32 packageId = generatePackageId(packageName);
+        bytes32 releaseId = generateReleaseId(packageName, version);
+        Package storage package = packages[packageId];
+
+        // If the package does not yet exist create it
+        if (package.exists == false) {
+            package.exists = true;
+            package.createdAt = block.timestamp;
+            package.updatedAt = block.timestamp;
+            package.name = packageName;
+            package.releaseCount = 0;
+            allPackageIds[packageCount] = packageId;
+            packageCount++;
+        } else {
+            package.updatedAt = block.timestamp;
+        }
+        _cutRelease(packageId, releaseId, packageName, version, manifestURI);
+        return releaseId;
+    }
+
+    function _cutRelease(
+        bytes32 packageId,
+        bytes32 releaseId,
+        string memory packageName,
+        string memory version,
+        string memory manifestURI
+    )
+        private
+    {
+        Release storage newRelease = releases[releaseId];
+        require(newRelease.exists == false, "release-already-exists");
+
+        // Store new release data
+        newRelease.exists = true;
+        newRelease.createdAt = block.timestamp;
+        newRelease.packageId = packageId;
+        newRelease.version = version;
+        newRelease.manifestURI = manifestURI;
+
+        releases[releaseId] = newRelease;
+        allReleaseIds[releaseCount] = releaseId;
+        releaseCount++;
+
+        // Update package's release count
+        Package storage package = packages[packageId];
+        bytes32 packageReleaseId = generatePackageReleaseId(packageId, package.releaseCount);
+        packageReleaseIndex[packageReleaseId] = releaseId;
+        package.releaseCount++;
+
+        // Log the release.
+        emit VersionRelease(packageName, version, manifestURI);
+    }
+
+    //
+    // ==============
+    // |  Read API  |
+    // ==============
+    //
+
+    /// @dev Returns the string name of the package associated with a package id
+    /// @param packageId The package id to look up
+    function getPackageName(bytes32 packageId)
+        public
+        view
+        returns (string memory packageName)
+    {
+        Package memory targetPackage = packages[packageId];
+        require (targetPackage.exists == true, "package-does-not-exist");
+        return targetPackage.name;
+    }
+
+    /// @dev Returns a slice of the array of all package ids for the named package.
+    /// @param offset The starting index for the slice.
+    /// @param limit  The length of the slice
+    function getAllPackageIds(uint offset, uint limit)
+        public
+        view
+        returns (
+            bytes32[] memory packageIds,
+            uint pointer
+        )
+    {
+        bytes32[] memory hashes;                 // Array of package ids to return
+        uint cursor = offset;                    // Index counter to traverse DB array
+        uint remaining;                          // Counter to collect `limit` packages
+
+        // Is request within range?
+        if (cursor < packageCount){
+
+            // Get total remaining records
+            remaining = packageCount - cursor;
+
+            // Number of records to collect is lesser of `remaining` and `limit`
+            if (remaining > limit ){
+                remaining = limit;
+            }
+
+            // Allocate return array
+            hashes = new bytes32[](remaining);
+
+            // Collect records.
+            while(remaining > 0){
+                bytes32 hash = allPackageIds[cursor];
+                hashes[remaining - 1] = hash;
+                remaining--;
+                cursor++;
+            }
+        }
+        return (hashes, cursor);
+    }
+
+    /// @dev Returns a slice of the array of all release hashes for the named package.
+    /// @param packageName Package name
+    /// @param offset The starting index for the slice.
+    /// @param limit  The length of the slice
+    function getAllReleaseIds(string memory packageName, uint offset, uint limit)
+        public
+        view
+        onlyIfPackageExists(packageName)
+        returns (
+            bytes32[] memory releaseIds,
+            uint pointer
+        )
+    {
+        bytes32 packageId = generatePackageId(packageName);
+        Package storage package = packages[packageId];
+        bytes32[] memory hashes;                                    // Release ids to return
+        uint cursor = offset;                                       // Index counter to traverse DB array
+        uint remaining;                                             // Counter to collect `limit` packages
+        uint numPackageReleases = package.releaseCount;		        // Total number of packages in registry
+
+        // Is request within range?
+        if (cursor < numPackageReleases){
+
+            // Get total remaining records
+            remaining = numPackageReleases - cursor;
+
+            // Number of records to collect is lesser of `remaining` and `limit`
+            if (remaining > limit ){
+                remaining = limit;
+            }
+
+            // Allocate return array
+            hashes = new bytes32[](remaining);
+
+            // Collect records.
+            while(remaining > 0){
+                bytes32 packageReleaseId = generatePackageReleaseId(packageId, cursor);
+                bytes32 hash = packageReleaseIndex[packageReleaseId];
+                hashes[remaining - 1] = hash;
+                remaining--;
+                cursor++;
+            }
+        }
+        return (hashes, cursor);
+    }
+
+
+    /// @dev Returns the package data for a release.
+    /// @param releaseId Release id
+    function getReleaseData(bytes32 releaseId)
+        public
+        view
+        returns (
+            string memory packageName, string memory version,
+            string memory manifestURI
+        )
+    {
+        Release memory targetRelease = releases[releaseId];
+        Package memory targetPackage = packages[targetRelease.packageId];
+        return (targetPackage.name, targetRelease.version, targetRelease.manifestURI);
+    }
+
+    /// @dev Returns the release id for a given name and version pair if present on registry.
+    /// @param packageName Package name
+    /// @param version Version string(ex: '1.0.0')
+    function getReleaseId(string memory packageName, string memory version)
+        public
+        view
+        onlyIfPackageExists(packageName)
+        onlyIfReleaseExists(packageName, version)
+        returns (bytes32 releaseId)
+    {
+        return generateReleaseId(packageName, version);
+    }
+
+    /// @dev Returns the number of packages stored on the registry
+    function numPackageIds() public view returns (uint totalCount)
+    {
+        return packageCount;
+    }
+
+    /// @dev Returns the number of releases for a given package name on the registry
+    /// @param packageName Package name
+    function numReleaseIds(string memory packageName)
+        public
+        view
+        onlyIfPackageExists(packageName)
+        returns (uint totalCount)
+    {
+        bytes32 packageId = generatePackageId(packageName);
+        Package storage package = packages[packageId];
+        return package.releaseCount;
+    }
+
+    /// @dev Returns a bool indicating whether the given release exists in this registry.
+    /// @param packageName Package Name
+    /// @param version version
+    function releaseExists(string memory packageName, string memory version)
+        public
+        view
+        onlyIfPackageExists(packageName)
+        returns (bool)
+    {
+        bytes32 releaseId = generateReleaseId(packageName, version);
+        Release storage targetRelease = releases[releaseId];
+        return targetRelease.exists;
+    }
+
+    /// @dev Returns a bool indicating whether the given package exists in this registry.
+    /// @param packageName Package Name
+    function packageExists(string memory packageName) public view returns (bool) {
+        bytes32 packageId = generatePackageId(packageName);
+        return packages[packageId].exists;
+    }
+
+    //
+    //  ====================
+    //  |  Hash Functions  |
+    //  ====================
+    // 
+
+    /// @dev Returns name hash for a given package name.
+    /// @param name Package name
+    function generatePackageId(string memory name)
+        public
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(name));
+    }
+
+    // @dev Returns release id that *would* be generated for a name and version pair on `release`.
+    // @param packageName Package name
+    // @param version Version string (ex: '1.0.0')
+    function generateReleaseId(
+        string memory packageName,
+        string memory version
+    )
+        public
+        view
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(packageName, version));
+    }
+
+    function generatePackageReleaseId(
+        bytes32 packageId,
+        uint packageReleaseCount
+    )
+        private
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(packageId, packageReleaseCount));
+    }
+
+
+    //
+    // ================
+    // |  Validation  |
+    // ================
+    //
+
+    /// @dev Returns boolean whether the provided package name is valid.
+    /// @param name The name of the package.
+    function validatePackageName(string memory name)
+        public
+        pure
+        returns (bool)
+    {
+        require (bytes(name).length > 2 && bytes(name).length < 255, "invalid-package-name");
+    }
+
+    /// @dev Returns boolean whether the input string has a length
+    /// @param value The string to validate.
+    function validateStringIdentifier(string memory value)
+        public
+        pure
+        returns (bool)
+    {
+        require (bytes(value).length != 0, "invalid-string-identifier");
+    }
+}

--- a/contracts/PackageRegistryInterface.sol
+++ b/contracts/PackageRegistryInterface.sol
@@ -1,0 +1,96 @@
+pragma solidity >=0.5.10;
+
+
+/// @title EIP 1319 Smart Contract Package Registry Interface
+/// @author Piper Merriam <pipermerriam@gmail.com>, Christopher Gewecke <christophergewecke@gmail.com>
+contract PackageRegistryInterface {
+
+    //
+    // +-------------+
+    // |  Write API  |
+    // +-------------+
+    //
+
+    /// @dev Creates a a new release for the named package.
+    /// @notice Will create a new release the given package with the given release information.
+    /// @param packageName Package name
+    /// @param version Version string (ex: 1.0.0)
+    /// @param manifestURI The URI for the release manifest for this release.
+    function release(
+        string memory packageName,
+        string memory version,
+        string memory manifestURI
+    )
+        public
+        returns (bytes32 releaseId);
+
+    //
+    // +------------+
+    // |  Read API  |
+    // +------------+
+    //
+
+    /// @dev Returns the string name of the package associated with a package id
+    /// @param packageId The package id to look up
+    function getPackageName(bytes32 packageId)
+        public
+        view
+        returns (string memory packageName);
+
+    /// @dev Returns a slice of the array of all package ids for the named package.
+    /// @param offset The starting index for the slice.
+    /// @param limit  The length of the slice
+    function getAllPackageIds(uint offset, uint limit)
+        public
+        view
+        returns (
+            bytes32[] memory packageIds,
+            uint pointer
+        );
+
+    /// @dev Returns a slice of the array of all release hashes for the named package.
+    /// @param packageName Package name
+    /// @param offset The starting index for the slice.
+    /// @param limit  The length of the slice
+    function getAllReleaseIds(string memory packageName, uint offset, uint limit)
+        public
+        view
+        returns (
+            bytes32[] memory releaseIds,
+            uint pointer
+        );
+
+    /// @dev Returns the package data for a release.
+    /// @param releaseId Release id
+    function getReleaseData(bytes32 releaseId)
+        public
+        view
+        returns (
+            string memory packageName,
+            string memory version,
+            string memory manifestURI
+        );
+
+    // @dev Returns release id that *would* be generated for a name and version pair on `release`.
+    // @param packageName Package name
+    // @param version Version string (ex: '1.0.0')
+    function generateReleaseId(string memory packageName, string memory version)
+        public
+        view
+        returns (bytes32 releaseId);
+
+    /// @dev Returns the release id for a given name and version pair if present on registry.
+    /// @param packageName Package name
+    /// @param version Version string(ex: '1.0.0')
+    function getReleaseId(string memory packageName, string memory version)
+        public
+        view
+        returns (bytes32 releaseId);
+
+    /// @dev Returns the number of packages stored on the registry
+    function numPackageIds() public view returns (uint totalCount);
+
+    /// @dev Returns the number of releases for a given package name on the registry
+    /// @param packageName Package name
+    function numReleaseIds(string memory packageName) public view returns (uint totalCount);
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+//const setPermissions = require('../config/permissions');
+
+module.exports = {
+
+  // Contants
+  constants: {
+    zeroAddress: '0x0000000000000000000000000000000000000000',
+    zeroBytes32: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  },
+
+  // Methods
+  now: () => Math.floor(Date.now() / 1000),
+  waitSecond: async() => new Promise(a => setTimeout(() => a(), 1000)),
+
+  // Status check: transactions
+  assertFailure: async (promise, reason) => {
+    try {
+      await promise;
+      assert.fail();
+    } catch(err){
+      assert(err.message.includes(reason), `Expected reason: "${err.message}"`);
+    }
+  },
+
+  // There's variant behavior across three clients when a require gate fails during a `.call`
+  // + ganache-cli > 6.1.3 / geth : if require contains reason string - no failure, null result.
+  // + testrpc-sc (coverage) : errors with a revert message
+  // + geth (no reason string): response that web3 doesn't handle correctly.
+  assertCallFailure: async (promise, expectedResult) => {
+    let result;
+    try {
+      result = await promise;
+      assert.fail();
+    } catch(err){
+
+      // testrpc-sc (ganache 6.1.0)
+      if (process.env.SOLIDITY_COVERAGE) {
+        assert(err.message.includes('revert'))
+
+      // ganache 6.1.4 & geth (should) return a null, false, zero result
+      // for all the return args
+      } else if (process.env.NETWORK === 'ganache' || process.env.NETWORK === 'geth') {
+        assert(result === expectedResult || err.message.includes('0x'));
+      }
+    }
+  },
+
+  //setPermissions: setPermissions,
+}

--- a/test/test_registry.js
+++ b/test/test_registry.js
@@ -1,0 +1,351 @@
+const helpers = require('./helpers');
+const constants = helpers.constants;
+const assertFailure = helpers.assertFailure;
+const PackageRegistry = artifacts.require("PackageRegistry");
+
+contract('PackageRegistry', function(accounts) {
+  let packageRegistry;
+
+  const releaseInfoA = ['test-r', '1.2.3.t.u', 'ipfs://some-ipfs-uri'];
+  const releaseInfoB = ['test-r', '2.3.4.v.y', 'ipfs://some-other-ipfs-uri'];
+  const releaseInfoC = ['test-r', '3.4.5.w.q', 'ipfs://yet-another-ipfs-uri'];
+  const packageIdA = '0xc4cf7a4b913721e342e4482e22bb88e365c91a339f8bd16f610009b083cc1f9a'
+  const releaseIdA = '0x09e922d900d5202de4dd159c3035a4325613f9f52245e371a0dc128f6666f119'
+  const releaseIdB = '0x1d87dce16481deba210017b90d960778c886c5f1ab77488302df9b09c90effe4'
+  const releaseIdC = '0x1f011fb8ea428670070fd2c145f07c02014ff1757e6749f2c05758f444cb9ce2'
+
+  async function assertRelease(
+    name,
+    version,
+    manifestUri,
+    receipt,
+    releaseData,
+  ) {
+    const packageId = await packageRegistry.generatePackageId(name)
+    const releaseId = await packageRegistry.generateReleaseId(name, version)
+
+    const exists = await packageRegistry.releaseExists(name, version);
+    const generatedId = await packageRegistry.generateReleaseId(name, version);
+    const getId = await packageRegistry.getReleaseId(name, version);
+
+    assert(generatedId === releaseId);
+    assert(getId === releaseId);
+    assert(exists);
+
+	// Test events are emitted
+    assert(receipt.logs[0].event === "VersionRelease")
+    assert(receipt.logs[0].args.packageName === name)
+    assert(receipt.logs[0].args.version === version)
+    assert(receipt.logs[0].args.manifestURI === manifestUrri)
+
+    const ids = await packageRegistry.getAllReleaseIds(name, 0, 100);
+    assert(ids.releaseIds.includes(releaseId));
+    assert(releaseData.packageName === name);
+    assert(releaseData.version === version);
+    assert(releaseData.manifestURI === manifestUri);
+  }
+
+  describe('Initialization', function() {
+    beforeEach(async function() {
+      packageRegistry = await PackageRegistry.new();
+    })
+
+    it('should release when initialized correctly', async function() {
+      let owner = await packageRegistry.owner()
+      assert(owner === accounts[0])
+
+      await packageRegistry.release(...releaseInfoA)
+      assert(await packageRegistry.packageExists('test-r') === true);
+    });
+  });
+
+  describe('Methods', function() {
+    beforeEach(async () => {
+      packageRegistry = await PackageRegistry.new();
+      nameHash = await packageRegistry.generatePackageId('test');
+    })
+
+    describe('packages', function() {
+      it('should retrieve all packages ids / package names', async function() {
+        nameHash = await packageRegistry.generatePackageId('test-r');
+
+        const packageIdA = await packageRegistry.generatePackageId(releaseInfoA[0]);
+        const packageIdB = await packageRegistry.generatePackageId(releaseInfoB[0]);
+
+        await packageRegistry.release(...releaseInfoA)
+        await packageRegistry.release(...releaseInfoB)
+
+        const ids = await packageRegistry.getAllPackageIds(0, 100);
+
+        assert(ids.packageIds.includes(packageIdA));
+        assert(ids.packageIds.includes(packageIdB));
+
+        const nameA = await packageRegistry.getPackageName(packageIdA);
+        const nameB = await packageRegistry.getPackageName(packageIdB);
+
+        assert(nameA === releaseInfoA[0]);
+        assert(nameB === releaseInfoB[0]);
+      });
+    });
+
+    describe('releases', function() {
+      it('should retrieve release by release id', async function() {
+        const releaseIdA = await packageRegistry.generateReleaseId(releaseInfoA[0], releaseInfoA[1])
+        const releaseIdB = await packageRegistry.generateReleaseId(releaseInfoB[0], releaseInfoB[1])
+
+        const responseA = await packageRegistry.release(...releaseInfoA)
+        const responseB = await packageRegistry.release(...releaseInfoB)
+
+        const releaseDataA = await packageRegistry.getReleaseData(releaseIdA)
+        const releaseDataB = await packageRegistry.getReleaseData(releaseIdB)
+
+        await assertRelease(...releaseInfoA, responseA, releaseDataA)
+        await assertRelease(...releaseInfoB, responseB, releaseDataB)
+      });
+
+      it('should retrieve a list of all release hashes', async function() {
+        const releaseInfoA = ['test-a', '1.2.3.a.b', 'ipfs://a']
+        const releaseInfoB = ['test-b', '2.3.4.c.d', 'ipfs://b']
+        const releaseInfoC = ['test-c', '3.4.5.e.f', 'ipfs://c']
+        const releaseInfoD = ['test-c', '3.4.6.e.f', 'ipfs://d']
+        const releaseInfoE = ['test-b', '2.4.5.c.d', 'ipfs://e']
+        const releaseInfoF = ['test-c', '3.5.5.e.f', 'ipfs://f']
+
+        await packageRegistry.release(...releaseInfoA)
+        await packageRegistry.release(...releaseInfoB)
+        await packageRegistry.release(...releaseInfoC)
+        await packageRegistry.release(...releaseInfoD)
+        await packageRegistry.release(...releaseInfoE)
+        await packageRegistry.release(...releaseInfoF)
+
+        const numPackageIds = await packageRegistry.numPackageIds();
+        const numReleasesA = await packageRegistry.numReleaseIds('test-a');
+        const numReleasesB = await packageRegistry.numReleaseIds('test-b');
+        const numReleasesC = await packageRegistry.numReleaseIds('test-c');
+
+        assert.equal(numPackageIds, 3)
+        assert.equal(numReleasesA, 1)
+        assert.equal(numReleasesB, 2)
+        assert.equal(numReleasesC, 3)
+      });
+
+      it('returns proper values for nonexistent numPackageIds, numReleaseIds', async () => {
+        const packageCount = await packageRegistry.packageCount();
+        const releaseCount = await packageRegistry.releaseCount();
+
+        const numNonExistentPackageIds = await packageRegistry.numPackageIds();
+
+        assert.equal(packageCount, 0)
+        assert.equal(releaseCount, 0)
+        assert.equal(numNonExistentPackageIds, 0)
+
+        await assertFailure(
+          packageRegistry.numReleaseIds(releaseInfoA[0]),
+          'package-does-not-exist'
+        )
+      });
+    });
+
+    describe('getAllReleaseIds', function() {
+      beforeEach(async function() {
+        await packageRegistry.release(...releaseInfoA)
+        await packageRegistry.release(...releaseInfoB)
+        await packageRegistry.release(...releaseInfoC)
+      });
+
+      it('returns proper values for valid numPackageIds, numReleaseIds', async () => {
+        const numPackageIds = await packageRegistry.numPackageIds();
+        const numReleaseIds = await packageRegistry.numReleaseIds('test-r');
+
+        assert.equal(numPackageIds, 1);
+        assert.equal(numReleaseIds, 3);
+      });
+
+      it('reverts for a non-existent release', async () => {
+        await assertFailure(
+          packageRegistry.getAllReleaseIds('test-none', 0, 20),
+          'package-does-not-exist'
+        )
+      });
+
+      it('cannot update an existing release', async () => {
+        await assertFailure(
+          packageRegistry.release(...releaseInfoA),
+          'release-already-exists'
+        )
+      });
+
+      it('returns ([],pointer) when pointer equals # of releases', async () => {
+        const limit = 20;
+        const totalCount = 3;
+        const result = await packageRegistry.getAllReleaseIds('test-r', totalCount, limit);
+
+        assert(Array.isArray(result.releaseIds));
+        assert(result.releaseIds.length === 0);
+        assert(result.pointer.toNumber() === totalCount)
+      });
+
+      it('returns releases and pointer with non-zero offset', async () => {
+        const limit = 20;
+        const totalCount = 1;
+        const result = await packageRegistry.getAllReleaseIds('test-r', totalCount, limit);
+
+        assert(Array.isArray(result.releaseIds));
+        assert(result.releaseIds.length === 2);
+        assert(result.pointer.toNumber() === 3)
+      });
+
+      it('returns ([],0) when limit param is zero', async () => {
+        const result = await packageRegistry.getAllReleaseIds('test-r', 0, 0);
+
+        assert(Array.isArray(result.releaseIds));
+        assert(result.releaseIds.length === 0);
+        assert(result.pointer.toNumber() === 0)
+      });
+
+      it('returns ([allReleaseIds], limit) when limit is greater than # of releases', async function() {
+        const limit = 4;
+        const result = await packageRegistry.getAllReleaseIds('test-r', 0, limit);
+
+        assert(result.pointer.toNumber() === 3);
+        assert(result.releaseIds.length === 3);
+      });
+
+      it('returns releases and pointer when limit is < # of releases', async function() {
+        const numReleases = await packageRegistry.numReleaseIds('test-r');
+        assert.equal(numReleases, 3);
+
+        const limit = 2;
+        const resultA = await packageRegistry.getAllReleaseIds('test-r', 0, limit);
+
+        // Initial results (2)
+        assert(resultA.releaseIds.length === limit);
+        assert(resultA.pointer.toNumber() === limit);
+
+        const resultB = await packageRegistry.getAllReleaseIds('test-r', resultA.pointer, limit);
+
+        // Remaining results (1)
+        assert(resultB.releaseIds.length === numReleases - limit);
+        assert.equal(resultB.pointer.toNumber(), numReleases);
+
+        const resultC = await packageRegistry.getAllReleaseIds('test-r', resultB.pointer, limit);
+
+        // Empty results, terminal index
+        assert(resultC.releaseIds.length === 0);
+        assert.equal(resultC.pointer.toNumber(), numReleases);
+
+        let allIds = resultA.releaseIds.concat(resultB.releaseIds);
+
+        assert.equal(allIds.length, numReleases);
+      });
+    });
+
+    describe('generate release id', function() {
+      it('generates release ids for existing packages', async function() {
+        const actualReleaseIdA = await packageRegistry.generateReleaseId(releaseInfoA[0], releaseInfoA[1]);
+        const actualReleaseIdB = await packageRegistry.generateReleaseId(releaseInfoB[0], releaseInfoB[1]);
+
+        assert.equal(actualReleaseIdA, releaseIdA)
+        assert.equal(actualReleaseIdB, releaseIdB)
+      });
+
+      it('generates release ids for unreleased packages', async function() {
+        const actualReleaseId = await packageRegistry.generateReleaseId('text-xx', '1.0.0');
+        assert(actualReleaseId.startsWith("0x"))
+        assert.equal(actualReleaseId.length, 66)
+      });
+    });
+
+    describe("get package name", function() {
+      it('reverts if package does not exist', async function() {
+        await assertFailure(
+          packageRegistry.getPackageName(web3.utils.fromAscii("xxx")),
+          'package-does-not-exist'
+        )
+      });
+    });
+
+    describe('get release id', function() {
+      ("reverts if release does not exist", async function() {
+        await assertFailure(
+          packageRegistry.getReleaseId('nonexistent', 'x.x.x'),
+          'release-does-not-exist'
+        )
+      });
+    });
+
+    describe('validation', function() {
+      it("reverts with empty package name", async function() {
+        await assertFailure(
+          packageRegistry.release('', 'x.x.x', 'ipfs://uri'),
+          'invalid-package-name'
+        )
+      });
+
+      it("reverts with single-char package name", async function() {
+        await assertFailure(
+          packageRegistry.release('x', 'x.x.x', 'ipfs://uri'),
+          'invalid-package-name'
+        )
+      });
+
+      it("reverts with too long package name", async function() {
+        await assertFailure(
+          packageRegistry.release('x'.repeat(256), 'x.x.x', 'ipfs://uri'),
+          'invalid-package-name'
+        )
+      });
+
+      it("reverts with empty version", async function() {
+        await assertFailure(
+          packageRegistry.release('pkg', '', 'ipfs://uri'),
+          'invalid-string-identifier'
+        )
+      });
+
+      it("reverts with empty uri", async function() {
+        await assertFailure(
+          packageRegistry.release('pkg', 'x.x.x', ''),
+          'invalid-string-identifier'
+        )
+      });
+    });
+
+    describe('ownership', function() {
+      const info = ['test-a', '1.2.3', 'ipfs://some-ipfs-uri'];
+      const owner = accounts[0];
+      const newOwner = accounts[1];
+      const notOwner = accounts[2];
+      const name = info[0];
+
+      beforeEach(async () => {
+        assert(await packageRegistry.packageExists(name) === false);
+      })
+
+      it('only the current owner can release packages', async function() {
+        const currentOwner = await packageRegistry.owner();
+        assert(currentOwner === owner);
+
+        await packageRegistry.release(...info, {
+          from: owner
+        });
+        await assertFailure(
+          packageRegistry.release('test-b', 'x.x.x', 'ipfs://uri', {
+            from: notOwner
+          }),
+          'caller is not the owner'
+        )
+
+        await packageRegistry.transferOwnership(newOwner);
+        const updatedOwner = await packageRegistry.owner();
+        assert(updatedOwner === newOwner);
+        await assertFailure(
+          packageRegistry.release('test-b', 'x.x.x', 'ipfs://uri', {
+            from: owner
+          }),
+          'caller is not the owner'
+        )
+      });
+    });
+  });
+});


### PR DESCRIPTION
A simplified implementation of https://github.com/ethpm/escape-truffle/blob/master/contracts/PackageRegistry.sol. 

Intention is to provide an ERC1319 compatible solidity registry that doesn't require deploying and linking multiple db contracts. This does not include the ability to delete releases, but I can include it if it's an important feature.

TODO:
Setup solidity coverage tests

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/61666661-548ad500-ac95-11e9-8566-d01c0d26170e.png)
